### PR TITLE
Add Visual Studio Code Python Settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,29 @@
+
+{
+  "python.analysis.autoIndent": true,
+  "python.analysis.autoFormatStrings": true,
+  "python.analysis.typeCheckingMode": "standard",
+  "python.languageServer": "Pylance",
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
+    },
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.wordBasedSuggestions": "allDocuments"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "files.exclude": {
+    ".ruff_cache": true,
+    ".pytest_cache": true,
+    "**/__pycache__": true,
+    "**/.ruff_cache": true,
+    "**/.pytest_cache": true,
+    ".coverage": true,
+    "coverage.xml": true
+  },
+}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the Visual Studio Code settings to improve the development environment for Python and Markdown files. The most important changes include enabling auto-indentation and auto-formatting for Python, configuring the Python language server, and setting up file exclusions.

VS Code settings improvements:

* Enabled auto-indentation and auto-formatting for Python (`.vscode/settings.json`)
* Configured the Python language server to use Pylance (`.vscode/settings.json`)
* Set up format-on-save and default formatter for Python and Markdown files (`.vscode/settings.json`)
* Excluded specific cache and coverage files from the workspace (`.vscode/settings.json`)