### PR TITLE
Fix Sync Repository Labels

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -31,7 +31,7 @@
   name: wontfix
   description: The issue is expected and will not be fixed
 # Languages
- color: 2b67c6
+- color: 2b67c6
   name: python
   description: Pull requests that update Python code
 - color: 000000


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/other-configurations/labels.yml` file. The change corrects the indentation for the `color` attribute under the `python` label.

* [`.github/other-configurations/labels.yml`](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dL34-R34): Corrected indentation for the `color` attribute under the `python` label.