### PR TITLE
Add Zizmor Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,10 +23,9 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
       # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.2.0
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -41,3 +40,28 @@ jobs:
           VALIDATE_PYTHON_RUFF: false
           VALIDATE_PYTHON_PYINK: false
           VALIDATE_NATURAL_LANGUAGE: false
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/code-checks.yml` file. The changes involve updating the linter version and adding a new job to check GitHub Actions using the `zizmor` tool.

Updates to GitHub Actions workflow:

* Updated the `super-linter` version from `v7.2.0` to `v7.2.1` for the `Lint Code Base` job.
* Added a new job named `run-zizmor` to check GitHub Actions with `zizmor`, including steps to install `uv`, run `zizmor`, and upload the SARIF file.