### PR TITLE
Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v7.2.1
@@ -53,7 +54,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v4.2.0
+        uses: astral-sh/setup-uv@v5.1.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -61,7 +62,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.27.9
+        uses: github/codeql-action/upload-sarif@v3.28.0
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   labeller:
     name: Label Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Label Pull Request
         uses: actions/labeler@v5.0.0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -9,17 +9,19 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   configure-labels:
     runs-on: ubuntu-latest
     name: Configure Labels
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: micnncim/action-label-syncer@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to GitHub Actions workflows to improve security and update dependencies. The changes focus on modifying permissions and updating action versions.

Security improvements:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R26): Set `persist-credentials` to `false` for `actions/checkout@v4.2.2` to improve security.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL7-R14): Removed global `pull-requests: write` permission and added it to the specific job to follow the principle of least privilege.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L12-R24): Removed global `pull-requests: write` permission and added it to the specific job to follow the principle of least privilege.

Dependency updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L56-R65): Updated `astral-sh/setup-uv` from `v4.2.0` to `v5.1.0` to use the latest version.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L56-R65): Updated `github/codeql-action/upload-sarif` from `v3.27.9` to `v3.28.0` to use the latest version.