### PR TITLE
Ignore and Remove previous results file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 mp/
 scripts/*/README.md
 scripts/*/.turbolift
+scripts/*/.turbolift_previous_results
 scripts/*/.gitignore
 scripts/*/work

--- a/scripts/9_upgrade_licenses/.turbolift_previous_results
+++ b/scripts/9_upgrade_licenses/.turbolift_previous_results
@@ -1,1 +1,0 @@
-/var/folders/3j/kgg3p93n7hv46q9h6vbkgdwh0000gn/T/turbolift-foreach-9_upgrade_licenses-430266110


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `scripts/9_upgrade_licenses/.turbolift_previous_results` file. The change removes a temporary file path, which is no longer needed.

* [`scripts/9_upgrade_licenses/.turbolift_previous_results`](diffhunk://#diff-dd67385f6c1a665f13b12f727384de2ede31a20dc4837687f91eda1960ea28f0L1): Removed a temporary file path.