### PR TITLE
Add Markdown Link Checks

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - ./
+  - ./docs
+excludedFiles:
+  - ./CHANGELOG.md
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -42,6 +42,23 @@ jobs:
           VALIDATE_PYTHON_PYINK: false
           VALIDATE_NATURAL_LANGUAGE: false
 
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Action to check for broken Markdown links in the repository and adds a configuration file for the link checker. The most important changes include the addition of a new job in the GitHub Actions workflow and the creation of a configuration file for the link checker.

### New GitHub Action for checking Markdown links:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R45-R61): Added a new job `check-markdown-links` that uses the `UmbrellaDocs/action-linkspector` GitHub Action to check for broken Markdown links. This job includes steps to checkout the repository, run the link checker, and report any issues as a GitHub PR review.

### Configuration for the link checker:

* [`.github/other-configurations/.linkspector.yml`](diffhunk://#diff-f9691f23ea6c4c34ecbaa23a98721e0aa3c7a94f2fcdd38f7b99fe863c5f6305R1-R7): Created a configuration file for the link checker specifying directories to include, files to exclude, and HTTP status codes that indicate a link is alive.