### PR TITLE
Fix Security Policy Links

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability within this project, please report it t
 
 To report a vulnerability:
 
-1. Go to the [Security tab](https://github.com/JackPlowman/github-stats/security) of the repository.
+1. Go to the [Security tab](https://github.com/JackPlowman/RepoSync/security) of the repository.
 2. Click on "Report a vulnerability".
 3. Follow the instructions to provide details about the vulnerability.
 
@@ -20,6 +20,6 @@ We release patches for security vulnerabilities in the following versions:
 
 ## Security Updates
 
-We will notify users about security updates through the repository's release notes and the [Security Advisories](https://github.com/JackPlowman/github-stats/security/advisories) section.
+We will notify users about security updates through the repository's release notes and the [Security Advisories](https://github.com/JackPlowman/RepoSync/security/advisories) section.
 
 Thank you for helping to keep this project secure.


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `docs/SECURITY.md` file to correct repository references for reporting vulnerabilities and security advisories.

Changes to repository references:

* Updated the link for reporting vulnerabilities to the correct repository in the [Security tab](https://github.com/JackPlowman/RepoSync/security).
* Updated the link for security advisories to the correct repository in the [Security Advisories](https://github.com/JackPlowman/RepoSync/security/advisories) section.