### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.0
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -81,7 +81,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.13
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -98,10 +98,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.10
+        uses: github/codeql-action/init@v3.28.13
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.10
+        uses: github/codeql-action/analyze@v3.28.13


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the versions of several GitHub Actions used in the `.github/workflows/code-checks.yml` file to ensure compatibility and take advantage of the latest features and fixes.

Version updates:

* Updated `UmbrellaDocs/action-linkspector` from version `v1.3.1` to `v1.3.2` for checking Markdown links.
* Updated `astral-sh/setup-uv` from version `v5.3.0` to `v5.4.0` for installing the latest version of `uv`.
* Updated `github/codeql-action/upload-sarif` from version `v3.28.10` to `v3.28.13` for uploading SARIF files.
* Updated `github/codeql-action/init` from version `v3.28.10` to `v3.28.13` for initializing CodeQL.
* Updated `github/codeql-action/analyze` from version `v3.28.10` to `v3.28.13` for performing CodeQL analysis.
