### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.2
+        uses: UmbrellaDocs/action-linkspector@49cf4f8da82db70e691bb8284053add5028fa244 # v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
         with:
           version: "latest"
       - name: Run zizmor 🌈

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -20,7 +20,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/Justfile
+++ b/Justfile
@@ -56,6 +56,22 @@ zizmor-check:
     zizmor .
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run -c .github/other-configurations/pinact.yml --update
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,5 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Pinact Checks:
+      run: just pinact-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the configuration and integration of the Pinact tool for workflow management and updates several GitHub Actions to use commit SHAs for improved reliability. The most significant changes include adding a Pinact configuration file, updating workflows to pin action versions, and integrating Pinact commands into the development process.

### Pinact Integration:
* [`.github/other-configurations/pinact.yml`](diffhunk://#diff-c2e684c61036562879b1062fb69ab67d446e19354f7a45ef92b14f611a051bc5R1-R9): Added a new configuration file for Pinact, specifying the schema, version, and rules for ignoring specific actions.
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR58-R73): Added commands for running, verifying, and updating Pinact operations to streamline its usage.
* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dR21-R22): Integrated Pinact checks into the pre-commit hooks to ensure consistency during development.

### Workflow Updates:
* `.github/workflows/code-checks.yml`: Updated multiple GitHub Actions to use commit SHAs instead of version tags to ensure reliability:
  - `super-linter/super-linter/slim`
  - `UmbrellaDocs/action-linkspector`
  - `astral-sh/setup-uv` [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L74-R74) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L92-R92)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL23-R23): Updated the `size-label-action` to use a commit SHA.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L26-R26): Updated the `action-label-syncer` to use a commit SHA.