### PR TITLE
Remove CodeQL Configuration

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -118,6 +118,5 @@ jobs:
         with:
           languages: actions
           queries: security-and-quality
-          config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.13


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes a custom CodeQL configuration file and updates the workflow to no longer reference it. The changes streamline the CodeQL analysis by relying on default configurations.

**CodeQL configuration removal:**

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Deleted the `actions/unpinned-tag` query filter by removing the entire `query-filters` section.

**Workflow update:**

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L121): Removed the `config-file` property pointing to the deleted CodeQL configuration file, simplifying the CodeQL analysis setup.