### PR TITLE
Remove Pinact Verify Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -120,17 +120,3 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.13
-
-  pinact-verify:
-    name: Pinact Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes an unused workflow from the GitHub Actions configuration file `.github/workflows/code-checks.yml`. The most notable change is the deletion of the `pinact-verify` job.

Workflow cleanup:

* Removed the `pinact-verify` job, including steps for checking out the repository and installing the latest version of `uv`. This job was no longer in use. (`[.github/workflows/code-checks.ymlL123-L136](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L123-L136)`)