### PR TITLE
Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -89,8 +89,10 @@ jobs:
           persist-credentials: false
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/Justfile
+++ b/Justfile
@@ -53,7 +53,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces changes to streamline the setup and execution of code checks in the CI workflow by integrating the `just` command runner and updating the `zizmor` command definitions. The most important changes include adding a step to set up `just` in the GitHub Actions workflow and defining a new `zizmor-check-sarif` command in the `Justfile`.

### CI Workflow Updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R92-R95): Added a new step to set up `just` using the `extractions/setup-just` action. Updated the `Run zizmor 🌈` step to use the `just zizmor-check-sarif` command instead of directly invoking the `uvx zizmor` command.

### `Justfile` Updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL56-R60): Introduced a new `zizmor-check-sarif` command to run `uvx zizmor` with `--persona=pedantic` and output results in SARIF format. This replaces the previous inline command in the workflow.