### PR TITLE
Pin all GitHub Actions

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,7 +20,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -83,20 +83,20 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Run zizmor 🌈
         run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.17
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -108,14 +108,14 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.17
+        uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         with:
           languages: actions
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.17
+        uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label Pull Request
-        uses: actions/labeler@v5.0.0
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
@@ -41,11 +41,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4.6.0
+        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
         with:
           comment-summary-in-pr: on-failure

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates GitHub Actions workflows to use commit SHA references for actions instead of version tags. This improves security by ensuring that the workflows use specific, immutable versions of actions. Additionally, some minor version updates were made to specific actions.

### Workflow security improvements:

* Updated all instances of `actions/checkout` to use the commit SHA `11bd71901bbe5b1630ceea73d27597364c9af683` instead of the `v4.2.2` tag across multiple workflows: `.github/workflows/clean-caches.yml`, `.github/workflows/code-checks.yml`, `.github/workflows/pull-request-tasks.yml`, and `.github/workflows/sync-labels.yml`. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL17-R17) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L23-R23) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L51-R51) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L70-R70) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L86-R99) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L111-R121) [[7]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL44-R49) [[8]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L21-R21)
* Updated `actions/labeler` to use the commit SHA `8558fd74291d67161a8a78ce36a881fa63b766a9` instead of the `v5.0.0` tag in `.github/workflows/pull-request-tasks.yml`.
* Updated `actions/dependency-review-action` to use the commit SHA `ce3cf9537a52e8119d91fd484ab5b8a807627bf8` instead of the `v4.6.0` tag in `.github/workflows/pull-request-tasks.yml`.

### Minor version updates:

* Updated `extractions/setup-just` to use the commit SHA `e33e0265a09d6d736e2ee1e0eb685ef1de4669ff` with a corrected tag comment `v3.0.0` in `.github/workflows/code-checks.yml`.
* Updated `github/codeql-action` (`init`, `analyze`, and `upload-sarif`) to use the commit SHA `60168efe1c415ce0f5521ea06d5c2062adbeed1b` instead of the `v3.28.17` tag in `.github/workflows/code-checks.yml`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L86-R99) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L111-R121)