### PR TITLE
Set Zizmor persona to auditor

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -48,7 +48,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -60,6 +60,6 @@ jobs:
     strategy:
       matrix:
         language: [actions, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -53,11 +53,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    uvx zizmor . --persona=pedantic
-
-# Run zizmor checking with sarif output
-zizmor-check-sarif:
-    uvx zizmor . --persona=pedantic --format sarif > results.sarif
+    uvx zizmor . --persona=auditor
 
 # ------------------------------------------------------------------------------
 # Pinact

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.13
+min_version: 1.11.14
 colors: true
 
 output:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several reusable workflow references across multiple GitHub Actions configuration files and makes minor adjustments to the `Justfile` and `lefthook.yml` configuration files.

### Workflow Updates:
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated the reusable workflow reference to `common-clean-caches.yml` from version `v2025.06.06.01` to `v2025.06.16.01`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L51-R51): Updated the reusable workflow references for `common-code-checks.yml` and `codeql-analysis.yml` to the latest version `v2025.06.16.01`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L51-R51) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L63-R63)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15): Updated the reusable workflow reference to `common-pull-request-tasks.yml` to version `v2025.06.16.01`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Updated the reusable workflow reference to `common-sync-labels.yml` to version `v2025.06.16.01`.

### Configuration Adjustments:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL56-R56): Changed the `zizmor-check` persona from `pedantic` to `auditor`, and removed the `zizmor-check-sarif` task.
* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dL2-R2): Updated the minimum version of Lefthook from `1.11.13` to `1.11.14`.