### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the documentation file pattern in the `.github/other-configurations/labeller.yml` configuration file. The change corrects the spelling of the license file to match the project's file name.

* Changed the documentation label pattern from `"LICENSE"` to `"LICENCE"` in `.github/other-configurations/labeller.yml` to match the project's file naming convention.