### PR TITLE
Add GitHub Workflow Permission Notes

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 env:
   FORCE_COLOR: 1
@@ -20,9 +19,9 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
-      actions: read
-      pull-requests: write
-      security-events: write
+      actions: read # Allow the workflow to read actions metadata
+      pull-requests: write # Allow the workflow to create and modify pull request comments
+      security-events: write # Allow the workflow to upload analysis results
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +30,7 @@ jobs:
     name: CodeQL Analysis
     permissions:
       contents: read
-      security-events: write
+      security-events: write # Allow the workflow to upload analysis results
     strategy:
       matrix:
         language: [actions, python]

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -10,7 +10,7 @@ jobs:
   common-pull-request-tasks:
     name: Common Pull Request Tasks
     permissions:
-      pull-requests: write
+      pull-requests: write # For writing labels and comments on PRs
     uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
     name: Configure Labels
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # For writing labels to the repository
     uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to clarify the purpose of specific permissions by adding explanatory comments. No functional changes were made; the updates are purely for documentation and maintainability.

Permissions documentation improvements:

* Added comments explaining the purpose of each permission in the `Common Code Checks`, `CodeQL Analysis`, `Common Pull Request Tasks`, and `Configure Labels` jobs within their respective workflow files. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L23-R24) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L34-R33) [[3]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL13-R13) [[4]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18)

Other minor cleanup:

* Removed the unused `packages: read` permission from the top-level permissions in `.github/workflows/code-checks.yml`.