### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@15462df20527afdc20ed59eff40f095bad0e6125 # v2026.02.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@c0ea11ac152de03bcdc6415d89b51a178f68e754 # v2026.07.05.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@15462df20527afdc20ed59eff40f095bad0e6125 # v2026.02.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@c0ea11ac152de03bcdc6415d89b51a178f68e754 # v2026.07.05.01
     with:
       language: ${{ matrix.language }}
 
@@ -34,6 +34,6 @@ jobs:
       actions: read # Allow the workflow to read actions metadata
       pull-requests: write # Allow the workflow to create and modify pull request comments
       security-events: write # Allow the workflow to upload analysis results
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@15462df20527afdc20ed59eff40f095bad0e6125 # v2026.02.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@c0ea11ac152de03bcdc6415d89b51a178f68e754 # v2026.07.05.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -11,6 +11,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write # For writing labels and comments on PRs
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@15462df20527afdc20ed59eff40f095bad0e6125 # v2026.02.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@c0ea11ac152de03bcdc6415d89b51a178f68e754 # v2026.07.05.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # For writing labels to the repository
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@15462df20527afdc20ed59eff40f095bad0e6125 # v2026.02.19.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@c0ea11ac152de03bcdc6415d89b51a178f68e754 # v2026.07.05.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ minimum_prek_version: "0.3.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-merge-conflict
         name: Check Merge Conflicts
@@ -20,26 +20,26 @@ repos:
         name: Detect Private Key
         description: Detects private keys that may have been added to the repository
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e # frozen: v8.30.1
     hooks:
       - id: gitleaks
         name: Gitleaks - Secret Detection
         description: Scan for secrets using Gitleaks
         language_version: "go1.25"
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # frozen: v1.7.12
     hooks:
       - id: actionlint
         name: Actionlint
         description: Linter for GitHub Actions workflow files
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-    rev: 3.6.0
+    rev: bebfac867564fbd992e5b45379b4b0568d5cb85b # frozen: 3.6.1
     hooks:
       - id: editorconfig-checker
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.22.0
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # frozen: v1.26.1
     hooks:
       - id: zizmor
         name: Zizmor
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.8.1
+          - prettier@3.9.4
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check
@@ -60,7 +60,7 @@ repos:
         language: python
         entry: just
         additional_dependencies:
-          - rust-just==1.46.0
+          - rust-just==1.55.1
         args: ["format-check"]
         files: "(?i)(^justfile$|\\.just$)"
         pass_filenames: false

--- a/Justfile
+++ b/Justfile
@@ -106,7 +106,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek autoupdate --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -119,4 +119,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request primarily updates dependencies and workflow configurations to use newer, frozen versions for improved stability and reproducibility. The most significant changes are upgrades to reusable workflow versions and pre-commit hooks, as well as adjustments to automation scripts.

**Workflow configuration updates:**

* Updated all references to reusable workflows in `.github/workflows` files (`common-clean-caches.yml`, `codeql-analysis.yml`, `common-code-checks.yml`, `common-pull-request-tasks.yml`, `common-sync-labels.yml`) to use the latest frozen commit (`c0ea11ac152de03bcdc6415d89b51a178f68e754`), ensuring consistency and up-to-date automation. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L26-R26) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L37-R37) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL14-R14) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19)

**Pre-commit hook and dependency upgrades:**

* Updated all pre-commit hook repositories in `.pre-commit-config.yaml` to newer, frozen revisions, including `pre-commit-hooks`, `gitleaks`, `actionlint`, `editorconfig-checker.python`, and `zizmor-pre-commit`. Also upgraded `prettier` and `rust-just` dependencies to their latest versions for formatting and task automation. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L7-R7) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L23-R42) [[3]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L55-R63)

**Automation script improvements:**

* Changed the `prek-update-hooks` target in `Justfile` to use `prek autoupdate --freeze`, ensuring that dependency updates are frozen for reproducibility.
* Removed the call to `prek-update-additional-dependencies` from the `update` target in `Justfile`, potentially streamlining the update process.